### PR TITLE
✨ Feature: 메인 페이지 components 구현 및 기존의 pt 단위 rem으로 수정

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -1,1 +1,5 @@
 @use './styles/main';
+
+body{
+  background-color: var(--grey-0);
+}

--- a/frontend/src/components/atoms/UlList/UlList.module.scss
+++ b/frontend/src/components/atoms/UlList/UlList.module.scss
@@ -1,0 +1,15 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+  min-width: 100%;
+  gap: 0.5rem;
+}
+
+.item{
+  cursor: pointer;
+  color: var(--grey-opacity-50);
+  &:hover {
+    color: var(--grey-100);
+  }
+}

--- a/frontend/src/components/atoms/UlList/UlList.tsx
+++ b/frontend/src/components/atoms/UlList/UlList.tsx
@@ -1,0 +1,23 @@
+// 리스트를 받아서 ul 태그로 감싸고 반환
+import styles from './UlList.module.scss';
+
+interface propsState {
+    list: string[];
+}
+
+export default function UlList(props: propsState) {
+    const { list } = props;
+
+    return (
+        <ul className={styles.list}>
+            {list.map((item, index) => (
+                <li
+                    className={`${styles['item']} fontSize-label fontWeight-bold`}
+                    key={index}
+                >
+                    {item}
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/frontend/src/components/atoms/WeatherContent/WeatherContent.module.scss
+++ b/frontend/src/components/atoms/WeatherContent/WeatherContent.module.scss
@@ -1,0 +1,12 @@
+@use '../../../styles/typography' as typo;
+
+span{
+  @include typo.typography('caption');
+  @include typo.font-weight('regular');
+  color: var(--grey-opacity-50);
+}
+
+.temperature{
+  @include typo.font-weight('bold');
+  color: var(--grey-100);
+}

--- a/frontend/src/components/atoms/WeatherContent/WeatherContent.tsx
+++ b/frontend/src/components/atoms/WeatherContent/WeatherContent.tsx
@@ -1,0 +1,20 @@
+import styles from './WeatherContent.module.scss';
+
+interface propsState {
+    surfaceTemperature: number;
+    summitTemperature: number;
+}
+
+export default function WeatherContent(props: propsState) {
+    const { surfaceTemperature, summitTemperature } = props;
+
+    return (
+        <>
+            <span>지표면 </span>
+            <span className={styles.temperature}>{surfaceTemperature}°C</span>
+
+            <span> | 정상 </span>
+            <span className={styles.temperature}>{summitTemperature}°C</span>
+        </>
+    );
+}

--- a/frontend/src/components/molecules/Dropdown/Dropdown.module.scss
+++ b/frontend/src/components/molecules/Dropdown/Dropdown.module.scss
@@ -1,0 +1,37 @@
+.wholeWrapper {
+  position: relative;
+}
+
+.selectButton {
+  display: flex;
+  width: max-content;
+  padding: 0.5rem 1rem 0.5rem 1.5rem;
+  align-items: center;
+  gap: 0.125rem;
+  background-color: var(--grey-opacity-white-70);
+  backdrop-filter: blur(50px);
+  border-radius: 6.25rem;
+}
+
+.dropdownWrapper {
+  position: absolute;
+  top: calc(100% + 1.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+  padding: 1rem;
+  border-radius: 1.5rem;
+  background-color: var(--grey-opacity-white-70);
+  backdrop-filter: blur(50px);
+}
+
+.dropdownTitleWrapper {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 1rem;
+  color: var(--grey-100);
+}
+

--- a/frontend/src/components/molecules/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/molecules/Dropdown/Dropdown.tsx
@@ -1,0 +1,33 @@
+import styles from './Dropdown.module.scss';
+import UlList from '../../atoms/UlList/UlList.tsx';
+
+// 드롭다운의 제목, 옵션 리스트를 받고 렌더링
+interface propsState {
+    title: string;
+    options: string[];
+}
+
+export default function Dropdown(props: propsState) {
+    const { title, options } = props;
+    let isOpen = true;
+
+    return (
+        <div className={styles.wholeWrapper}>
+            <div className={styles.selectButton}>
+                <h3 className={`text-grey-100 fontSize-label fontWeight-bold`}>
+                    {title}
+                </h3>
+            </div>
+            {isOpen && (
+                <div className={styles.dropdownWrapper}>
+                    <div className={styles.dropdownTitleWrapper}>
+                        <h3 className={`fontSize-label fontWeight-bold`}>
+                            {title}
+                        </h3>
+                    </div>
+                    <UlList list={options} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/molecules/MountainCard/MountainCard.module.scss
+++ b/frontend/src/components/molecules/MountainCard/MountainCard.module.scss
@@ -1,0 +1,27 @@
+@use '../../../styles/typography' as typo;
+
+.cardWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 15.75rem;
+  min-height: 33.25rem;
+  background: var(--grey-50);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+}
+
+.weatherNavMessage {
+  @include typo.typography('caption');
+  @include typo.font-weight('bold');
+  color: var(--grey-20);
+  background-color: var(--grey-98);
+  border-radius: 1.5rem;
+  padding: 0.5rem 1.25rem;
+}
+
+.cardFooter {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/frontend/src/components/molecules/MountainCard/MountainCard.tsx
+++ b/frontend/src/components/molecules/MountainCard/MountainCard.tsx
@@ -1,0 +1,32 @@
+// 산 이름, 날씨 정보를 받고 렌더링
+import WeatherContent from '../../atoms/WeatherContent/WeatherContent.tsx';
+import styles from './MountainCard.module.scss';
+
+interface propsState {
+    mountainName: string;
+    surfaceTemperature: number;
+    summitTemperature: number;
+}
+
+export default function MountainCard(props: propsState) {
+    const { mountainName, surfaceTemperature, summitTemperature } = props;
+
+    return (
+        <div className={styles.cardWrapper}>
+            <div>
+                <WeatherContent
+                    surfaceTemperature={surfaceTemperature}
+                    summitTemperature={summitTemperature}
+                />
+            </div>
+            <div className={styles.cardFooter}>
+                <h2
+                    className={`text-grey-100 fontWeight-bold fontSize-headline`}
+                >
+                    {mountainName}
+                </h2>
+                <p className={styles.weatherNavMessage}>날씨 보러가기</p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/organisms/MountainCardContainer/MountainCardContainer.module.scss
+++ b/frontend/src/components/organisms/MountainCardContainer/MountainCardContainer.module.scss
@@ -1,0 +1,17 @@
+.mountainCardContainer {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  overflow-x: auto; /*가로 스크롤*/
+  padding: 1.5rem 2rem;
+  width: 100%;
+
+  box-sizing: border-box; /* 패딩을 너비에 포함시킴 */
+
+  /* 스크롤바 숨기기 */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE, Edge */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
+}

--- a/frontend/src/components/organisms/MountainCardContainer/MountainCardContainer.tsx
+++ b/frontend/src/components/organisms/MountainCardContainer/MountainCardContainer.tsx
@@ -1,0 +1,49 @@
+import MountainCard from '../../molecules/MountainCard/MountainCard.tsx';
+import styles from './MountainCardContainer.module.scss';
+
+const data = [
+    {
+        name: '설악산',
+        surfaceTemperature: 20,
+        summitTemperature: 15,
+    },
+    {
+        name: '한라산',
+        surfaceTemperature: 25,
+        summitTemperature: 20,
+    },
+    {
+        name: '지리산',
+        surfaceTemperature: 22,
+        summitTemperature: 18,
+    },
+    {
+        name: '오대산',
+        surfaceTemperature: 19,
+        summitTemperature: 14,
+    },
+    {
+        name: '태백산',
+        surfaceTemperature: 21,
+        summitTemperature: 16,
+    },
+    {
+        name: '덕유산',
+        surfaceTemperature: 23,
+        summitTemperature: 17,
+    },
+];
+
+export default function MountainCardContainer() {
+    return (
+        <div className={styles.mountainCardContainer}>
+            {data.map((mountain) => (
+                <MountainCard
+                    mountainName={mountain.name}
+                    surfaceTemperature={mountain.surfaceTemperature}
+                    summitTemperature={mountain.summitTemperature}
+                />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/components/organisms/SearchBar/SearchBar.module.scss
+++ b/frontend/src/components/organisms/SearchBar/SearchBar.module.scss
@@ -1,0 +1,19 @@
+.search {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.searchBarWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--grey-100);
+  border-radius: 6.25rem;
+  background-color: var(--grey-opacity-white-70);
+  backdrop-filter: blur(50px);
+  width: max-content;
+  padding: 0.75rem;
+}

--- a/frontend/src/components/organisms/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/organisms/SearchBar/SearchBar.tsx
@@ -1,0 +1,28 @@
+// URL을 보고 홈, 제보에 맞게 검색바를 다르게 렌더링
+import Dropdown from '../../molecules/Dropdown/Dropdown.tsx';
+import styles from './SearchBar.module.scss';
+
+export default function SearchBar() {
+    const searchBarTitle = '어디 날씨를 확인해볼까요?';
+    const searchBarMessage = '를 오르는';
+    let isHomaPage = true;
+
+    return (
+        <div className={styles.search}>
+            <h2 className={`text-grey-100 fontSize-label fontWeight-bold`}>
+                {searchBarTitle}
+            </h2>
+            <div className={styles.searchBarWrapper}>
+                <Dropdown title='산' options={['설악산', '한라산', '지리산']} />
+                <Dropdown title='코스' options={['코스1', '코스2', '코스3']} />
+                {searchBarMessage}
+                {isHomaPage && (
+                    <Dropdown
+                        title='요일은?'
+                        options={['월', '화', '수', '목', '금']}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,9 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <StrictMode>
+        <App />
+    </StrictMode>,
+);

--- a/frontend/src/styles/typography.scss
+++ b/frontend/src/styles/typography.scss
@@ -6,24 +6,28 @@ $font-weights: (
         'bold': 700
 );
 
+// pt → rem 변환 함수
+@function pt-to-rem($pt) {
+  @return $pt / 16 * 1rem;
+}
+
 // PC 타이포그래피 크기
 $pc-sizes: (
-        'display': 64pt,
-        'headline': 40pt,
-        'title': 32pt,
-        'label': 24pt,
-        'body': 20pt,
-        'caption': 16pt
+        'display': pt-to-rem(64),
+        'headline': pt-to-rem(40),
+        'title': pt-to-rem(32),
+        'label': pt-to-rem(24),
+        'body': pt-to-rem(20),
+        'caption': pt-to-rem(15)
 );
 
 // 모바일 타이포그래피 크기
 $mobile-sizes: (
-        'display': 32pt,
-        'headline': 24pt,
-        'title': 20pt,
-        'label': 14pt,
-        'body': 16pt,
-        'caption': 12pt
+        'display': pt-to-rem(32),
+        'title': pt-to-rem(20),
+        'body': pt-to-rem(16),
+        'label': pt-to-rem(14),
+        'caption': pt-to-rem(12)
 );
 
 $breakpoint-mobile: 768px;


### PR DESCRIPTION
<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->
<img width="1728" height="1117" alt="스크린샷 2025-07-31 오후 7 20 33" src="https://github.com/user-attachments/assets/c91189c8-61a2-4ff3-8629-efd1550ebce4" />



- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## 작업사항
- 사용하지 않는 index.css 삭제
- 메인 페이지의 atoms UI 구현
   -> UIList (현재는 드롭다운의 옵션에서 사용)
   -> WeatherContent (현재는 산 카드의 날씨정보에서 사용)
- 메인 페이지의 molucules UI 구현
   -> Dropdown (검색바의 드롭다운)
   -> MountainCard (메인페이지의 산 카드)
- 메인 페이지의 organisms UI 구현
   -> MountainCardContainer (메인페이지의 산 카드 컨테이너)
   -> SearchBar (메인페이지의 검색창)

## 변경로직
- 기존의 pt단위를 rem단위로 변환
