### PR TITLE
[FE] - ✨ Feature : 일기예보 첫페이지 UI 구현 및 자잘한 버그 수정

### DIFF
--- a/frontend/src/components/atoms/Text/CommonText.tsx
+++ b/frontend/src/components/atoms/Text/CommonText.tsx
@@ -10,12 +10,16 @@ interface PropsState {
     fontWeight?: FontWeightType;
     color?: string;
     children: React.ReactNode;
+    flexColoumn?: boolean;
 }
 
 export default function CommonText(props: PropsState) {
-    const { TextTag, color, fontSize, fontWeight, children } = props;
+    const { TextTag, color, fontSize, fontWeight, children, flexColoumn } =
+        props;
 
     const textStyle = css`
+        ${flexColoumn &&
+        'display: flex; flex-direction: column; align-items: center;'}
         ${createTextStyle({
             fontSize,
             fontWeight,

--- a/frontend/src/components/molecules/MountainInfoPreview/MountainInfoPreview.tsx
+++ b/frontend/src/components/molecules/MountainInfoPreview/MountainInfoPreview.tsx
@@ -1,0 +1,104 @@
+import { css } from '@emotion/react';
+import CommonText from '../../atoms/Text/CommonText';
+import MultiLocationTemperature from '../MultiLocationTemperature/MultiLocationTemperature';
+import Icon from '../../atoms/Icon/Icons';
+
+interface PropsState {
+    time: string;
+    dist: number;
+}
+
+export default function MountainInfoPreview({ time, dist }: PropsState) {
+    const weatherData = createWeatherData({
+        surfaceTemperature: 12,
+        summitTemperature: 20,
+    });
+
+    return (
+        <div css={wrapperStyles}>
+            <div css={dummySteyls} />
+
+            <p css={textWrapperStyles}>
+                <CommonText {...WhiteTextProps}>{`${time}`}</CommonText>
+                <CommonText {...TextProps}>동안</CommonText>
+                <CommonText {...WhiteTextProps}>{`${dist}Km`}</CommonText>
+                <CommonText {...TextProps}>를 올라야해요</CommonText>
+            </p>
+            <div css={lineStyles}>
+                <Icon
+                    name='clear-day'
+                    color='grey-100'
+                    width={1.5}
+                    height={1.5}
+                />
+                <MultiLocationTemperature data={weatherData} />
+            </div>
+        </div>
+    );
+}
+
+const wrapperStyles = css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.2rem;
+    width: 38rem;
+    height: 50dvh;
+    margin-top: 2%;
+`;
+
+const textWrapperStyles = css`
+    & :nth-of-type(-n + 3) {
+        margin-left: 0.4rem;
+    }
+`;
+
+const lineStyles = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    & > svg {
+        margin-right: 0.5rem;
+    }
+`;
+
+const dummySteyls = css`
+    width: 100%;
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    background: red;
+`;
+
+const WhiteTextProps = {
+    TextTag: 'span',
+    color: 'grey-100',
+    fontWeight: 'bold',
+    fontSize: 'body',
+} as const;
+
+const TextProps = {
+    TextTag: 'span',
+    color: 'grey-90',
+    fontWeight: 'bold',
+    fontSize: 'body',
+} as const;
+
+function createWeatherData({
+    surfaceTemperature,
+    summitTemperature,
+}: {
+    surfaceTemperature: number;
+    summitTemperature: number;
+}) {
+    return [
+        {
+            location: '지표면 온도',
+            temperature: surfaceTemperature,
+        },
+        {
+            location: '정상 온도',
+            temperature: summitTemperature,
+        },
+    ];
+}

--- a/frontend/src/components/molecules/MultiLocationTemperature/MultiLocationTemperature.tsx
+++ b/frontend/src/components/molecules/MultiLocationTemperature/MultiLocationTemperature.tsx
@@ -15,7 +15,7 @@ export default function MultiLocationTemperature({
     separator = ' | ',
 }: MultiLocationProps) {
     return (
-        <>
+        <div>
             {data.map(({ location, temperature }, idx) => (
                 <LocationTemperatureItem
                     location={location}
@@ -24,7 +24,7 @@ export default function MultiLocationTemperature({
                     separator={separator}
                 />
             ))}
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/components/molecules/WeatherIndex/WeatherIndex.module.scss
+++ b/frontend/src/components/molecules/WeatherIndex/WeatherIndex.module.scss
@@ -1,9 +1,0 @@
-.text-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    width: max-content;
-    box-sizing: border-box;
-    border-radius: 6.25rem;
-}

--- a/frontend/src/components/molecules/WeatherIndex/WeatherIndex.tsx
+++ b/frontend/src/components/molecules/WeatherIndex/WeatherIndex.tsx
@@ -1,12 +1,13 @@
-import styles from './WeatherIndex.module.scss';
-import Text from '../../atoms/Text/Text';
+import type { FontSizeType } from '../../../types/themeTypes';
+import { css } from '@emotion/react';
+import { theme } from '../../../theme/theme';
 
 interface WeatherIdx {
     color: string;
-    backGroundColor: String;
+    backGroundColor: string;
     height: string;
     padding: string;
-    fontSize: string;
+    fontSize: FontSizeType;
     text: string;
 }
 
@@ -14,25 +15,55 @@ interface PropsState {
     type: WeatherType;
 }
 type WeatherType = '매우좋음' | '좋음' | '보통' | '나쁨';
+const { colors, typography } = theme;
 
 function WeatherIndex(props: WeatherIdx) {
     const { color, backGroundColor, height, padding, fontSize, text } = props;
+
     return (
         <div
-            className={`bg-${backGroundColor} ${styles['text-wrapper']}`}
-            style={{ padding: padding, height: height }}
+            css={[
+                wrapperStyles,
+                createDynamicStyles(
+                    backGroundColor,
+                    padding,
+                    height,
+                    color,
+                    fontSize,
+                ),
+            ]}
         >
-            <Text
-                textTag='span'
-                fontSize={fontSize}
-                fontWeight='bold'
-                color={color}
-            >
-                {`등산지수 ${text}`}
-            </Text>
+            {`등산지수 ${text}`}
         </div>
     );
 }
+
+const wrapperStyles = css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: max-content;
+    box-sizing: border-box;
+    border-radius: 6.25rem;
+`;
+
+const createDynamicStyles = (
+    backGroundColor: string,
+    padding: string,
+    height: string,
+    color: string,
+    fontSize: FontSizeType,
+) => {
+    return css`
+        font-size: ${typography.fontSize[fontSize]};
+        font-weight: ${typography.fontWeight.bold};
+        background-color: ${backGroundColor};
+        padding: ${padding};
+        height: ${height};
+        color: ${color};
+    `;
+};
 
 function WeatherIndexVivid(props: PropsState) {
     const { type } = props;
@@ -41,20 +72,20 @@ function WeatherIndexVivid(props: PropsState) {
 
     switch (type) {
         case '매우좋음':
-            color = 'status-light-excellent';
-            backGroundColor = 'status-normal-excellent';
+            color = colors.status.light.excellent;
+            backGroundColor = colors.status.normal.excellent;
             break;
         case '좋음':
-            color = 'status-light-good';
-            backGroundColor = 'status-normal-good';
+            color = colors.status.light.good;
+            backGroundColor = colors.status.normal.good;
             break;
         case '보통':
-            color = 'status-light-average';
-            backGroundColor = 'status-normal-average';
+            color = colors.status.light.average;
+            backGroundColor = colors.status.normal.average;
             break;
         case '나쁨':
-            color = 'status-light-bad';
-            backGroundColor = 'status-normal-bad';
+            color = colors.status.light.bad;
+            backGroundColor = colors.status.normal.bad;
             break;
     }
 
@@ -77,20 +108,20 @@ function WeatherIndexLight(props: PropsState) {
 
     switch (type) {
         case '매우좋음':
-            color = 'status-normal-excellent';
-            backGroundColor = 'status-regular-excellent';
+            color = colors.status.normal.excellent;
+            backGroundColor = colors.status.regular.excellent;
             break;
         case '좋음':
-            color = 'status-normal-good';
-            backGroundColor = 'status-regular-good';
+            color = colors.status.normal.good;
+            backGroundColor = colors.status.regular.good;
             break;
         case '보통':
-            color = 'status-normal-average';
-            backGroundColor = 'status-regular-average';
+            color = colors.status.normal.average;
+            backGroundColor = colors.status.regular.average;
             break;
         case '나쁨':
-            color = 'status-normal-bad';
-            backGroundColor = 'status-regular-bad';
+            color = colors.status.normal.bad;
+            backGroundColor = colors.status.regular.bad;
             break;
     }
 

--- a/frontend/src/components/organisms/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/organisms/SearchBar/SearchBar.tsx
@@ -8,7 +8,7 @@ import Icon from '../../atoms/Icon/Icons.tsx';
 import SearchBarText from '../../atoms/Text/SearchBarText.tsx';
 
 interface propsState {
-    searchBarTitle: string;
+    searchBarTitle?: string;
     searchBarMessage: string;
     isHomePage: boolean;
     mountainCourseData: { title: string; options: string[] }[];
@@ -67,7 +67,6 @@ const searchBarStyle = css`
         colors,
         colorString: 'greyOpacityWhite-70',
     })};
-    backdrop-filter: blur(50px);
     width: max-content;
     padding: 0.75rem;
 `;
@@ -80,7 +79,6 @@ const searchButtonStyle = css`
         colors,
         colorString: 'greyOpacityWhite-70',
     })};
-    backdrop-filter: blur(50px);
 
     margin-left: auto;
     border-radius: 50%;

--- a/frontend/src/components/templates/ForecastMain.tsx
+++ b/frontend/src/components/templates/ForecastMain.tsx
@@ -1,0 +1,82 @@
+import { css } from '@emotion/react';
+import MountainInfoPreview from '../molecules/MountainInfoPreview/MountainInfoPreview';
+import Header from '../organisms/Header/Header';
+import SearchBar from '../organisms/SearchBar/SearchBar';
+import { WeatherIndexLight } from '../molecules/WeatherIndex/WeatherIndex';
+import CommonText from '../atoms/Text/CommonText';
+import Icon from '../atoms/Icon/Icons';
+
+export default function ForecastMain() {
+    return (
+        <div css={wrapperStyles}>
+            <Header />
+            <SearchBar {...searchBarProps} />
+            <MountainInfoPreview time='0401' dist={5} />
+
+            <WeatherIndexLight type='매우좋음' />
+            <div css={downStyles}>
+                <CommonText {...textProps}>
+                    <span
+                        css={css`
+                            margin-bottom: 0.4rem;
+                        `}
+                    >
+                        스크롤하여 초단기 날씨를
+                    </span>
+                    <span
+                        css={css`
+                            margin-bottom: 0.6rem;
+                        `}
+                    >
+                        확인하세요
+                    </span>
+                </CommonText>
+                <Icon
+                    name='chevron-down-double'
+                    color='grey-100'
+                    width={3}
+                    height={3}
+                />
+            </div>
+        </div>
+    );
+}
+
+const mountainCourseData = [
+    {
+        title: '산',
+        options: ['설악산', '한라산', '지리산'],
+    },
+    {
+        title: '코스',
+        options: ['코스1', '코스2', '코스3'],
+    },
+];
+
+const searchBarProps = {
+    searchBarMessage: '를 오르는',
+    isHomePage: true,
+    mountainCourseData,
+};
+
+const textProps = {
+    TextTag: 'p',
+    color: 'grey-100',
+    fontWeight: 'medium',
+    fontSize: 'body',
+    flexColoumn: true,
+} as const;
+
+const downStyles = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;
+const wrapperStyles = css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: calc(100dvh);
+    justify-content: space-between;
+`;


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

<img width="852" height="908" alt="스크린샷 2025-08-08 오후 6 35 04" src="https://github.com/user-attachments/assets/fa07e35a-aec4-4602-b382-b4f9bd23de01" />

## PR 설명
일기예보 첫 페이지 레이아웃을 구현하고, 관련 스타일 및 공통 컴포넌트(CommonText)에 기능을 추가했습니다. 또한, backdrop-filter 관련 스타일 충돌 이슈를 해결하고, Emotion 기반 스타일로 일관성을 맞추었습니다.


## 작업사항
- CommonText에 글자를 아래로 나열할 수 있고 정렬되는 props 추가
- 상위 backdrop-filter로 인해 하위 요소 스타일이 무시되는 문제 해결
- Emotion 스타일 적용으로 기존 스타일 로직 일부 변경
- div 태그 래퍼 추가를 통한 레이아웃 안정성 확보
- infoPreview 컴포넌트 뼈대 구현 (SVG를 아직 받지 못해서  → dummy style 적용)
- 일기예보 첫 페이지 전체 레이아웃 구성

## 변경로직
- CommonText.tsx에 스타일 적용을 위한 boolean props 추가
- backdrop-filter 충돌 문제를 상위 계층의 css 속성을 삭제
- 기존 CSS → Emotion 기반 스타일로 마이그레이션
- 레이아웃 정리를 위해 div 래퍼 태그 추가 적용
- infoPreview: 추후 SVG 삽입을 고려하여 임시 스타일로 구성

close #83
