### PR TITLE
[FE] - ✨ Feature: 메인페이지 상태 구현

### DIFF
--- a/frontend/src/components/atoms/Li/TextLi.tsx
+++ b/frontend/src/components/atoms/Li/TextLi.tsx
@@ -3,9 +3,14 @@ import { theme } from '../../../theme/theme';
 
 interface PropsState {
     children: string;
+    onClick?: () => void;
 }
-export default function TextLi({ children }: PropsState) {
-    return <li css={textStyles}>{children}</li>;
+export default function TextLi({ children, onClick }: PropsState) {
+    return (
+        <li css={textStyles} onClick={onClick}>
+            {children}
+        </li>
+    );
 }
 
 const { colors, typography } = theme;

--- a/frontend/src/components/molecules/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/molecules/Dropdown/Dropdown.tsx
@@ -4,21 +4,42 @@ import { css } from '@emotion/react';
 import { getColor } from '../../../utils/utils.ts';
 import { theme } from '../../../theme/theme.ts';
 import Icon from '../../atoms/Icon/Icons.tsx';
+import { useState, useEffect } from 'react';
 
-// 드롭다운의 제목, 옵션 리스트를 받고 렌더링
-interface propsState {
-    title: string;
-    options: string[];
-    isOpenOptions?: boolean;
+interface Option {
+    id: string;
+    name: string;
 }
 
-export default function Dropdown(props: propsState) {
-    const { title, options, isOpenOptions = 'false' } = props;
+interface PropsState {
+    title: string;
+    options: Option[];
+    isOpenOptions?: boolean;
+    onToggle: () => void;
+    onSelect?: (option: Option) => void;
+}
+
+export default function Dropdown(props: PropsState) {
+    const { title, options, isOpenOptions = false, onToggle, onSelect } = props;
+
+    const [selector, setSelector] = useState({ id: '0', name: title });
+
+    useEffect(() => {
+        if (onSelect && selector.name !== title) {
+            onSelect(selector);
+        }
+    }, [selector, title, onSelect]);
+
+    const optionListProps = createOptionListProps({
+        options,
+        setSelector,
+        onToggle,
+    });
 
     return (
         <div css={dropdownStyle}>
-            <div css={selectorTitleStyle}>
-                <SearchBarText>{title}</SearchBarText>
+            <div css={selectorTitleStyle} onClick={onToggle}>
+                <SearchBarText>{selector.name}</SearchBarText>
                 <div css={selectorChevronButtonStyle}>
                     <Icon {...chevronIconProps} />
                 </div>
@@ -32,14 +53,35 @@ export default function Dropdown(props: propsState) {
                         </div>
                     </div>
                     <ul>
-                        {options.map((option) => (
-                            <TextLi>{option}</TextLi>
+                        {optionListProps.map((liProps) => (
+                            <TextLi {...liProps} />
                         ))}
                     </ul>
                 </div>
             )}
         </div>
     );
+}
+
+function createOptionListProps({
+    options,
+    setSelector,
+    onToggle,
+}: {
+    options: Option[];
+    setSelector: React.Dispatch<
+        React.SetStateAction<{ id: string; name: string }>
+    >;
+    onToggle: () => void;
+}) {
+    return options.map((option) => ({
+        key: option.id,
+        onClick: () => {
+            setSelector({ id: option.id, name: option.name });
+            onToggle();
+        },
+        children: option.name,
+    }));
 }
 
 const chevronIconProps = {
@@ -54,6 +96,7 @@ const { colors } = theme;
 const dropdownStyle = css`
     position: relative;
     width: max-content;
+    cursor: pointer;
 `;
 
 const chevronButtonStyle = css`

--- a/frontend/src/components/molecules/MountainCard/MountainCardFooter.tsx
+++ b/frontend/src/components/molecules/MountainCard/MountainCardFooter.tsx
@@ -4,11 +4,11 @@ import { getColor } from '../../../utils/utils.ts';
 import { theme } from '../../../theme/theme.ts';
 import { HeadlineHeading } from '../../atoms/Heading/Heading.tsx';
 
-export default function MountainCardFooter({
-    mountainName,
-}: {
+interface PropsState {
     mountainName: string;
-}) {
+}
+
+export default function MountainCardFooter({ mountainName }: PropsState) {
     return (
         <div>
             <HeadlineHeading HeadingTag='h3'>{mountainName}</HeadlineHeading>

--- a/frontend/src/components/molecules/MountainCard/MountainCardHeader.tsx
+++ b/frontend/src/components/molecules/MountainCard/MountainCardHeader.tsx
@@ -4,13 +4,13 @@ import { css } from '@emotion/react';
 import { getColor } from '../../../utils/utils.ts';
 import { theme } from '../../../theme/theme.ts';
 
-interface propsState {
+interface PropsState {
     weatherIconName: string;
     surfaceTemperature: number;
     summitTemperature: number;
 }
 
-export default function MountainCardHeader(props: propsState) {
+export default function MountainCardHeader(props: PropsState) {
     const { weatherIconName, surfaceTemperature, summitTemperature } = props;
 
     const weatherData = createWeatherData({

--- a/frontend/src/components/molecules/Text/MultiLocationTemperature.tsx
+++ b/frontend/src/components/molecules/Text/MultiLocationTemperature.tsx
@@ -18,6 +18,7 @@ export default function MultiLocationTemperature({
         <div>
             {data.map(({ location, temperature }, idx) => (
                 <LocationTemperatureItem
+                    key={`${location}-${temperature}`}
                     location={location}
                     temperature={temperature}
                     isLast={idx === data.length - 1}

--- a/frontend/src/components/organisms/Common/SearchBar.tsx
+++ b/frontend/src/components/organisms/Common/SearchBar.tsx
@@ -1,58 +1,145 @@
-// URL을 보고 홈, 제보에 맞게 검색바를 다르게 렌더링
 import Dropdown from '../../molecules/Dropdown/Dropdown.tsx';
 import { LabelHeading } from '../../atoms/Heading/Heading.tsx';
 import { css } from '@emotion/react';
 import { theme } from '../../../theme/theme.ts';
 import Icon from '../../atoms/Icon/Icons.tsx';
 import SearchBarText from '../../atoms/Text/SearchBarText.tsx';
+import { useState } from 'react';
+import {
+    createHandleSubmit,
+    createHandleToggleDropdown,
+} from './utils/utils.ts';
 
-type pageName = 'main' | 'report' | 'safety';
+type PageName = 'main' | 'report' | 'safety';
+type DropdownType = 'mountain' | 'course' | 'weekday' | null;
 
-interface propsState {
-    searchBarTitle?: string;
-    searchBarMessage: string;
-    pageName?: pageName;
-    mountainData: string[];
-    courseData?: string[];
+interface Option {
+    id: string;
+    name: string;
 }
 
-export default function SearchBar(props: propsState) {
+interface PropsState {
+    searchBarTitle?: string;
+    searchBarMessage: string;
+    pageName?: PageName;
+    mountainOptions: Option[];
+    courseOptions: Option[];
+    weekdayOptions?: Option[];
+    onSubmit: (values: {
+        mountain: Option;
+        course?: Option;
+        weekday?: Option;
+    }) => void;
+    onMountainChange: (mountain: Option) => void;
+}
+
+export default function SearchBar(props: PropsState) {
     const {
         searchBarTitle,
         searchBarMessage,
         pageName = 'main',
-        mountainData,
-        courseData,
+        mountainOptions,
+        courseOptions,
+        weekdayOptions,
+        onSubmit,
+        onMountainChange,
     } = props;
+
+    const [openDropdown, setOpenDropdown] = useState<DropdownType>(null);
+    const [selectedMountain, setSelectedMountain] =
+        useState<Option>(defaultMountain);
+    const [selectedCourse, setSelectedCourse] = useState<Option>(defaultCourse);
+    const [selectedWeekday, setSelectedWeekday] =
+        useState<Option>(defaultWeekday);
 
     const isMainPage = pageName === 'main';
     const isReportPage = pageName === 'report';
     const isSafetyPage = pageName === 'safety';
 
+    const handleToggleDropdown = createHandleToggleDropdown({
+        setOpenDropdown,
+        openDropdown,
+    });
+    const handleSubmit = createHandleSubmit({
+        isMainPage,
+        isReportPage,
+        selectedMountain,
+        selectedCourse,
+        selectedWeekday,
+        onSubmit,
+    });
+
+    const dropdownProps = {
+        mountain: createDropdownProps({
+            title: '산',
+            options: mountainOptions,
+            dropdownType: 'mountain',
+            openDropdown,
+            handleToggleDropdown,
+            onSelectValue: (selected: Option) => {
+                setSelectedMountain(selected);
+                onMountainChange(selected);
+            },
+        }),
+        course: createDropdownProps({
+            title: '코스',
+            options: courseOptions,
+            dropdownType: 'course',
+            openDropdown,
+            handleToggleDropdown,
+            onSelectValue: setSelectedCourse,
+        }),
+        weekday: createDropdownProps({
+            title: weekdayData.title,
+            options: weekdayOptions ?? weekdayData.options,
+            dropdownType: 'weekday',
+            openDropdown,
+            handleToggleDropdown,
+            onSelectValue: setSelectedWeekday,
+        }),
+    };
+
     return (
         <div css={searchBarContainerStyle}>
             <LabelHeading HeadingTag='h2'>{searchBarTitle}</LabelHeading>
-            <div css={searchBarStyle}>
-                <Dropdown title='산' options={mountainData} />
+            <form css={searchBarStyle} onSubmit={handleSubmit}>
+                <Dropdown {...dropdownProps.mountain} />
                 {(isMainPage || isReportPage) && (
-                    <Dropdown title='코스' options={courseData || []} />
+                    <Dropdown {...dropdownProps.course} />
                 )}
                 <SearchBarText>{searchBarMessage}</SearchBarText>
-                {isMainPage && (
-                    <Dropdown
-                        title={weekdayData.title}
-                        options={weekdayData.options}
-                    />
-                )}
+                {isMainPage && <Dropdown {...dropdownProps.weekday} />}
                 {(isMainPage || isSafetyPage) && (
-                    <button css={searchButtonStyle}>
+                    <button type='submit' css={searchButtonStyle}>
                         <Icon {...searchButtonIconProps} />
                     </button>
                 )}
-            </div>
+            </form>
         </div>
     );
 }
+
+const createDropdownProps = ({
+    title,
+    options,
+    dropdownType,
+    openDropdown,
+    handleToggleDropdown,
+    onSelectValue,
+}: {
+    title: string;
+    options: Option[];
+    dropdownType: DropdownType;
+    openDropdown: DropdownType;
+    handleToggleDropdown: (dropdown: DropdownType) => void;
+    onSelectValue: (selected: Option) => void;
+}) => ({
+    title,
+    options,
+    isOpenOptions: openDropdown === dropdownType,
+    onToggle: () => handleToggleDropdown(dropdownType),
+    onSelect: onSelectValue,
+});
 
 const searchButtonIconProps = {
     name: 'search-sm',
@@ -95,12 +182,12 @@ const searchButtonStyle = css`
 const weekdayData = {
     title: '요일은?',
     options: [
-        '월요일',
-        '화요일',
-        '수요일',
-        '목요일',
-        '금요일',
-        '토요일',
-        '일요일',
+        { id: 'today', name: '오늘' },
+        { id: 'tomorrow', name: '내일' },
+        { id: 'dayaftertomorrow', name: '글피' },
     ],
 };
+
+const defaultMountain: Option = { id: '0', name: '산' };
+const defaultCourse: Option = { id: '0', name: '코스' };
+const defaultWeekday: Option = { id: '0', name: '요일은?' };

--- a/frontend/src/components/organisms/Common/utils/utils.ts
+++ b/frontend/src/components/organisms/Common/utils/utils.ts
@@ -1,0 +1,45 @@
+type DropdownType = 'mountain' | 'course' | 'weekday' | null;
+interface Option {
+    id: string;
+    name: string;
+}
+export const createHandleToggleDropdown =
+    ({
+        setOpenDropdown,
+        openDropdown,
+    }: {
+        setOpenDropdown: React.Dispatch<React.SetStateAction<DropdownType>>;
+        openDropdown: DropdownType;
+    }) =>
+    (dropdown: DropdownType) => {
+        setOpenDropdown(openDropdown === dropdown ? null : dropdown);
+    };
+
+export const createHandleSubmit =
+    ({
+        isMainPage,
+        isReportPage,
+        selectedMountain,
+        selectedCourse,
+        selectedWeekday,
+        onSubmit,
+    }: {
+        isMainPage: boolean;
+        isReportPage: boolean;
+        selectedMountain: Option;
+        selectedCourse: Option;
+        selectedWeekday: Option;
+        onSubmit: (values: {
+            mountain: Option;
+            course?: Option;
+            weekday?: Option;
+        }) => void;
+    }) =>
+    (e: React.FormEvent) => {
+        e.preventDefault();
+        onSubmit({
+            mountain: selectedMountain,
+            course: isMainPage || isReportPage ? selectedCourse : undefined,
+            weekday: isMainPage ? selectedWeekday : undefined,
+        });
+    };

--- a/frontend/src/components/organisms/Loading/Loading.tsx
+++ b/frontend/src/components/organisms/Loading/Loading.tsx
@@ -1,0 +1,82 @@
+import { DisplayHeading } from '../../atoms/Heading/Heading.tsx';
+import CommonText from '../../atoms/Text/CommonText.tsx';
+import { css, keyframes } from '@emotion/react';
+import { theme } from '../../../theme/theme.ts';
+
+interface PropsState {
+    mountainTitle: string;
+    mountainDescription: string;
+}
+
+export default function Loading(props: PropsState) {
+    const { mountainTitle, mountainDescription } = props;
+
+    return (
+        <div css={fullScreenContainerStyle}>
+            <div css={loadingPageBackGroundStyle} />
+            <div css={loadingProgressStyle} />
+            <div css={overBackgroundStyle}>
+                <DisplayHeading HeadingTag='h1'>{mountainTitle}</DisplayHeading>
+                <CommonText TextTag='p' fontSize='body' fontWeight='medium'>
+                    {mountainDescription}
+                </CommonText>
+            </div>
+        </div>
+    );
+}
+
+const { colors } = theme;
+
+const fullScreenContainerStyle = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: ${colors.grey[0]};
+`;
+
+const fillProgress = keyframes`
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+`;
+
+const loadingProgressStyle = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 0.2rem;
+    z-index: 10;
+    background-color: ${colors.grey[100]};
+
+    transform-origin: left center;
+    transform: scaleX(0);
+    will-change: transform;
+
+    animation: ${fillProgress} 3s linear forwards;
+`;
+
+const overBackgroundStyle = css`
+    position: relative;
+    z-index: 10;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 60%;
+    height: 100vh;
+    gap: 2rem;
+    margin: 0 auto;
+`;
+
+const loadingPageBackGroundStyle = css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.15;
+    filter: blur(50px);
+`;

--- a/frontend/src/components/organisms/Main/MountainCard.tsx
+++ b/frontend/src/components/organisms/Main/MountainCard.tsx
@@ -1,27 +1,34 @@
-// 산 이름, 날씨 정보를 받고 렌더링
 import { css } from '@emotion/react';
 import { getColor } from '../../../utils/utils.ts';
 import { theme } from '../../../theme/theme.ts';
 import MountainCardFooter from '../../molecules/MountainCard/MountainCardFooter.tsx';
 import MountainCardHeader from '../../molecules/MountainCard/MountainCardHeader.tsx';
+import type { SelectedMountainData } from '../../../types/mountainTypes';
 
-interface propsState {
+interface PropsState {
     mountainName: string;
+    mountainDescription: string;
     weatherIconName: string;
     surfaceTemperature: number;
     summitTemperature: number;
+    onClick: (data: SelectedMountainData) => void;
 }
 
-export default function MountainCard(props: propsState) {
+export default function MountainCard(props: PropsState) {
     const {
         mountainName,
+        mountainDescription,
         weatherIconName,
         surfaceTemperature,
         summitTemperature,
+        onClick,
     } = props;
 
     return (
-        <div css={cardStyle}>
+        <div
+            css={cardStyle}
+            onClick={() => onClick({ mountainName, mountainDescription })}
+        >
             <MountainCardHeader
                 weatherIconName={weatherIconName}
                 surfaceTemperature={surfaceTemperature}

--- a/frontend/src/components/templates/Main/MainSearchSection.tsx
+++ b/frontend/src/components/templates/Main/MainSearchSection.tsx
@@ -1,0 +1,57 @@
+import SearchBar from '../../organisms/Common/SearchBar.tsx';
+import { useState } from 'react';
+import type {
+    MountainCourse,
+    MountainData,
+    SelectedMountainData,
+} from '../../../types/mountainTypes';
+import {
+    createHandleSubmit,
+    refactorCoursesDataToOptions,
+    refactorMountainDataToOptions,
+} from './utils/utils.ts';
+
+interface PropsState {
+    mountainsData: MountainData[];
+    onSearchClick: (data: SelectedMountainData) => void;
+    onFormValidChange: (isValid: boolean) => void;
+}
+
+interface Option {
+    id: string;
+    name: string;
+}
+
+export default function MainSearchSection(props: PropsState) {
+    const { mountainsData, onSearchClick, onFormValidChange } = props;
+    const [coursesData, setCoursesData] =
+        useState<MountainCourse[]>(initCoursesData);
+
+    const mountainOptions: Option[] =
+        refactorMountainDataToOptions(mountainsData);
+
+    const courseOptions: Option[] = refactorCoursesDataToOptions(coursesData);
+
+    const handleSubmit = createHandleSubmit({
+        mountainsData,
+        onSearchClick,
+        onFormValidChange,
+    });
+    const handleMountainChange = (data: Option) => {
+        // 선택한 산에 해당하는 코스 데이터를 가져올 예정, setCoursesData를 통해 상태 업데이트
+    };
+
+    return (
+        <SearchBar
+            searchBarTitle='어디 날씨를 확인해볼까요?'
+            searchBarMessage='를 오르는'
+            pageName='main'
+            mountainOptions={mountainOptions}
+            courseOptions={courseOptions}
+            onSubmit={handleSubmit}
+            onMountainChange={handleMountainChange}
+        />
+    );
+}
+
+const initCoursesData = [{ courseId: '1', courseName: '산을 선택해주세요' }];

--- a/frontend/src/components/templates/Main/MountainCardSection.tsx
+++ b/frontend/src/components/templates/Main/MountainCardSection.tsx
@@ -1,0 +1,131 @@
+import MountainCard from '../../organisms/Main/MountainCard.tsx';
+import { css } from '@emotion/react';
+import { useEffect } from 'react';
+import type {
+    MountainData,
+    SelectedMountainData,
+} from '../../../types/mountainTypes';
+import { refactorMountainsData } from './utils/utils.ts';
+
+interface PropsState {
+    mountainsData: MountainData[];
+    setMountainsData: (data: MountainData[]) => void;
+    onCardClick: (data: SelectedMountainData) => void;
+}
+
+export default function MountainCardSection(props: PropsState) {
+    const { mountainsData, setMountainsData, onCardClick } = props;
+
+    useEffect(() => {
+        setMountainsData(MountainsData);
+    });
+
+    const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+        event.currentTarget.scrollLeft += Number(event.deltaY);
+    };
+
+    const data = refactorMountainsData(mountainsData);
+
+    return (
+        <div css={mountainCardContainerStyle} onWheel={handleWheel}>
+            {data.map((mountain) => (
+                <MountainCard
+                    key={mountain.mountainName}
+                    onClick={() => {
+                        onCardClick({
+                            mountainName: mountain.mountainName,
+                            mountainDescription: mountain.mountainDescription,
+                        });
+                    }}
+                    {...mountain}
+                />
+            ))}
+        </div>
+    );
+}
+
+const mountainCardContainerStyle = css`
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    overflow-x: auto;
+    padding: 1.5rem 2rem;
+    width: 100%;
+    box-sizing: border-box;
+
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`;
+
+const MountainsData = [
+    {
+        mountainName: '태백산',
+        mountainImageUrl: 'https://cdn.example.com/images/taebaek.png',
+        mountainDescription: '한겨울 설경이 아름다운 산입니다.',
+        weatherMetric: {
+            precipitationType: 'NONE',
+            sky: 'SUNNY',
+            surfaceTemperature: 23.5,
+            topTemperature: 18.2,
+        },
+    },
+    {
+        mountainName: '지리산',
+        mountainImageUrl: 'https://cdn.example.com/images/jiri.png',
+        mountainDescription: '한국에서 두 번째로 높은 산입니다.',
+        weatherMetric: {
+            precipitationType: 'RAIN',
+            sky: 'OVERCAST',
+            surfaceTemperature: 20.1,
+            topTemperature: 15.3,
+        },
+    },
+    {
+        mountainName: '백두산',
+        mountainImageUrl: 'https://cdn.example.com/images/taebaek.png',
+        mountainDescription: '한겨울 설경이 아름다운 산입니다.',
+        weatherMetric: {
+            precipitationType: 'NONE',
+            sky: 'SUNNY',
+            surfaceTemperature: 23.5,
+            topTemperature: 18.2,
+        },
+    },
+    {
+        mountainName: '한라산',
+        mountainImageUrl: 'https://cdn.example.com/images/jiri.png',
+        mountainDescription: '한국에서 두 번째로 높은 산입니다.',
+        weatherMetric: {
+            precipitationType: 'RAIN',
+            sky: 'OVERCAST',
+            surfaceTemperature: 20.1,
+            topTemperature: 15.3,
+        },
+    },
+    {
+        mountainName: '설악산',
+        mountainImageUrl: 'https://cdn.example.com/images/taebaek.png',
+        mountainDescription: '한겨울 설경이 아름다운 산입니다.',
+        weatherMetric: {
+            precipitationType: 'NONE',
+            sky: 'SUNNY',
+            surfaceTemperature: 23.5,
+            topTemperature: 18.2,
+        },
+    },
+    {
+        mountainName: '가야산',
+        mountainImageUrl: 'https://cdn.example.com/images/jiri.png',
+        mountainDescription: '한국에서 두 번째로 높은 산입니다.',
+        weatherMetric: {
+            precipitationType: 'RAIN',
+            sky: 'OVERCAST',
+            surfaceTemperature: 20.1,
+            topTemperature: 15.3,
+        },
+    },
+];

--- a/frontend/src/components/templates/Main/utils/utils.ts
+++ b/frontend/src/components/templates/Main/utils/utils.ts
@@ -1,0 +1,91 @@
+import type {
+    MountainCourse,
+    MountainData,
+    SelectedMountainData,
+} from '../../../../types/mountainTypes';
+import { convertToIconName } from '../../../../utils/utils.ts';
+
+export function refactorMountainsData(data: MountainData[]) {
+    return data.map((mountain) => ({
+        mountainName: mountain.mountainName,
+        mountainDescription: mountain.mountainDescription,
+        weatherIconName: convertToIconName({
+            precipitationType: mountain.weatherMetric.precipitationType,
+            sky: mountain.weatherMetric.sky,
+        }),
+        surfaceTemperature: mountain.weatherMetric.surfaceTemperature,
+        summitTemperature: mountain.weatherMetric.topTemperature,
+    }));
+}
+
+interface Option {
+    id: string;
+    name: string;
+}
+export function refactorMountainDataToOptions(
+    mountainsData: MountainData[],
+): Option[] {
+    return mountainsData.map((mountain, index) => ({
+        id: index.toString(),
+        name: mountain.mountainName,
+    }));
+}
+
+export function refactorCoursesDataToOptions(
+    coursesData: MountainCourse[],
+): Option[] {
+    return coursesData.map((course) => ({
+        id: course.courseId,
+        name: course.courseName,
+    }));
+}
+
+export function validate(values: {
+    mountain: Option;
+    course?: Option;
+    weekday?: Option;
+}) {
+    if (values.mountain.id === '0') return '산을 선택해주세요';
+    if (values.course?.id === '0') return '코스를 선택해주세요';
+    if (values.weekday?.id === '0') return '요일을 선택해주세요';
+    return null;
+}
+
+export function createHandleSubmit({
+    mountainsData,
+    onSearchClick,
+    onFormValidChange,
+}: {
+    mountainsData: MountainData[];
+    onSearchClick: (data: SelectedMountainData) => void;
+    onFormValidChange: (isValid: boolean) => void;
+}) {
+    return (values: {
+        mountain: Option;
+        course?: Option;
+        weekday?: Option;
+    }) => {
+        const error = validate(values);
+        if (error) {
+            alert(error);
+            onFormValidChange(false);
+            return;
+        }
+
+        onFormValidChange(true);
+
+        const mountain = mountainsData.find(
+            (mountain) => mountain.mountainName === values.mountain.name,
+        );
+        if (!mountain) return;
+
+        const payload: SelectedMountainData = {
+            mountainName: mountain.mountainName,
+            mountainDescription: mountain.mountainDescription,
+            course: values.course?.name,
+            timeToGo: values.weekday?.name,
+        };
+
+        onSearchClick(payload);
+    };
+}

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -1,40 +1,85 @@
-import MountainCard from '../../components/organisms/Main/MountainCard.tsx';
+import { type Dispatch, type SetStateAction, useState } from 'react';
+import MainSearchSection from '../../components/templates/Main/MainSearchSection.tsx';
+import MountainCardSection from '../../components/templates/Main/MountainCardSection.tsx';
+import Loading from '../../components/organisms/Loading/Loading.tsx';
 import { css } from '@emotion/react';
-import SearchBar from '../../components/organisms/Common/SearchBar.tsx';
+import type {
+    MountainData,
+    SelectedMountainData,
+} from '../../types/mountainTypes';
+import { createFormValidChange, createStartLoading } from './utils/utils.ts';
 
 export default function MainPage() {
-    const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
-        event.preventDefault();
-        event.currentTarget.scrollLeft += Number(event.deltaY);
-    };
+    const [isOpen, setIsOpen] = useState(false);
+    const [mountainsData, setMountainsData] = useState<MountainData[]>([]);
+    const [selectedMountain, setSelectedMountain] =
+        useState<SelectedMountainData | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
 
-    const isOpen = false;
+    const handleStartLoading = createStartLoading({
+        setSelectedMountain,
+        setIsLoading,
+    });
+    const handleFormValidChange = createFormValidChange({ setIsOpen });
+
+    const mainSearchSectionProps = createMainSearchSectionProps({
+        mountainsData,
+        onSearchClick: handleStartLoading,
+        onFormValidChange: handleFormValidChange,
+    });
+    const mountainCardSectionProps = createMountainCardSectionProps({
+        mountainsData,
+        setMountainsData,
+        onCardClick: handleStartLoading,
+    });
+
+    if (isLoading) {
+        return <Loading {...loadingProps(selectedMountain!)} />;
+    }
 
     return (
         <>
             {isOpen && <div css={backgroundStyle} />}
             <div css={overBackgroundStyle}>
-                <SearchBar {...searchBarProps} />
+                <MainSearchSection {...mainSearchSectionProps} />
             </div>
-            <div css={mountainCardContainerStyle} onWheel={handleWheel}>
-                {data.map((mountain) => (
-                    <MountainCard {...mountain} />
-                ))}
-            </div>
+            <MountainCardSection {...mountainCardSectionProps} />
         </>
     );
 }
 
-const mountainData = ['설악산', '한라산', '지리산'];
-const courseData = ['코스1', '코스2', '코스3'];
+const createMountainCardSectionProps = ({
+    mountainsData,
+    setMountainsData,
+    onCardClick,
+}: {
+    mountainsData: MountainData[];
+    setMountainsData: Dispatch<SetStateAction<MountainData[]>>;
+    onCardClick: (data: SelectedMountainData) => void;
+}) => ({
+    mountainsData,
+    setMountainsData,
+    onCardClick,
+});
 
-const searchBarProps = {
-    searchBarTitle: '어디 날씨를 확인해볼까요?',
-    searchBarMessage: '를 오르는',
-    pageName: 'main',
-    mountainData,
-    courseData,
-} as const;
+const createMainSearchSectionProps = ({
+    mountainsData,
+    onSearchClick,
+    onFormValidChange,
+}: {
+    mountainsData: MountainData[];
+    onSearchClick: (data: SelectedMountainData) => void;
+    onFormValidChange: (isValid: boolean) => void;
+}) => ({
+    mountainsData,
+    onSearchClick,
+    onFormValidChange,
+});
+
+const loadingProps = (selectedMountain: SelectedMountainData) => ({
+    mountainTitle: selectedMountain.mountainName,
+    mountainDescription: selectedMountain.mountainDescription,
+});
 
 const backgroundStyle = css`
     position: absolute;
@@ -56,59 +101,3 @@ const overBackgroundStyle = css`
 
     margin-bottom: 2rem;
 `;
-
-const mountainCardContainerStyle = css`
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    overflow-x: auto;
-    padding: 1.5rem 2rem;
-    width: 100%;
-    box-sizing: border-box;
-
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-
-    &::-webkit-scrollbar {
-        display: none;
-    }
-`;
-
-const data = [
-    {
-        mountainName: '설악산',
-        weatherIconName: 'clear-day',
-        surfaceTemperature: 20,
-        summitTemperature: 15,
-    },
-    {
-        mountainName: '한라산',
-        weatherIconName: 'partly-cloudy-day',
-        surfaceTemperature: 25,
-        summitTemperature: 20,
-    },
-    {
-        mountainName: '지리산',
-        weatherIconName: 'rain',
-        surfaceTemperature: 22,
-        summitTemperature: 18,
-    },
-    {
-        mountainName: '오대산',
-        weatherIconName: 'snow',
-        surfaceTemperature: 19,
-        summitTemperature: 14,
-    },
-    {
-        mountainName: '태백산',
-        weatherIconName: 'thunderstorm',
-        surfaceTemperature: 21,
-        summitTemperature: 16,
-    },
-    {
-        mountainName: '덕유산',
-        weatherIconName: 'yellow-dust',
-        surfaceTemperature: 23,
-        summitTemperature: 17,
-    },
-];

--- a/frontend/src/pages/MainPage/utils/utils.ts
+++ b/frontend/src/pages/MainPage/utils/utils.ts
@@ -1,0 +1,26 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { SelectedMountainData } from '../../../types/mountainTypes';
+
+export function createStartLoading({
+    setSelectedMountain,
+    setIsLoading,
+}: {
+    setSelectedMountain: Dispatch<SetStateAction<SelectedMountainData | null>>;
+    setIsLoading: Dispatch<SetStateAction<boolean>>;
+}) {
+    return (mountainInfo: SelectedMountainData) => {
+        setSelectedMountain(mountainInfo);
+        setIsLoading(true);
+        setTimeout(() => setIsLoading(false), 3000);
+    };
+}
+
+export function createFormValidChange({
+    setIsOpen,
+}: {
+    setIsOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+    return (isValid: boolean) => {
+        setIsOpen(!isValid);
+    };
+}

--- a/frontend/src/types/mountainTypes.d.ts
+++ b/frontend/src/types/mountainTypes.d.ts
@@ -1,0 +1,23 @@
+export interface MountainData {
+    mountainName: string;
+    mountainImageUrl: string;
+    mountainDescription: string;
+    weatherMetric: {
+        precipitationType: string;
+        sky: string;
+        surfaceTemperature: number;
+        topTemperature: number;
+    };
+}
+
+export interface SelectedMountainData {
+    mountainName: string;
+    mountainDescription: string;
+    course?: string;
+    timeToGo?: string;
+}
+
+export interface MountainCourse {
+    courseId: string;
+    courseName: string;
+}

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -35,3 +35,25 @@ export function createTextStyle({
         line-height: ${lineHeight};
     `;
 }
+
+export function convertToIconName({
+    precipitationType,
+    sky,
+}: {
+    precipitationType: string;
+    sky: string;
+}) {
+    if (precipitationType === 'NONE') {
+        if (sky === 'SUNNY') return 'clear-day';
+        if (sky === 'CLOUDY') return 'partly-cloudy-day';
+        if (sky === 'OVERCAST') return 'cloudy';
+    }
+    if (precipitationType === 'RAIN' || precipitationType === 'SLEET')
+        return 'rain';
+    if (precipitationType === 'SNOW') return 'snow';
+    if (precipitationType === 'SHOWER') return 'shower-rain';
+    if (precipitationType === 'DRIZZLE' || precipitationType === 'DRIZZLE_SNOW')
+        return 'occasional-rain';
+    if (precipitationType === 'SNOW_FLURRY') return 'occasional-snow';
+    return '';
+}


### PR DESCRIPTION

<img width="1840" height="1121" alt="스크린샷 2025-08-17 오후 11 41 46" src="https://github.com/user-attachments/assets/82b57803-93c8-4880-bff4-0bb6eaecd26a" />
<img width="1840" height="1121" alt="스크린샷 2025-08-17 오후 11 42 11" src="https://github.com/user-attachments/assets/a3a74fed-d804-46c1-98dc-1f6bac627407" />
<img width="1840" height="1121" alt="스크린샷 2025-08-17 오후 11 42 02" src="https://github.com/user-attachments/assets/28f009e8-bf74-41d1-a139-4301be30652b" />



## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
메인페이지에서 백엔드와 연동이 되지 않은 상황에서의 상태를 관리했습니다.


## 작업사항
  - 날씨 형식 → 아이콘 이름으로 변환하는 유틸 함수 추가
  - MultiLocationTemperature에 key 속성 추가
  - Dropdown 개선: 옵션에 id 추가, 선택 시 상태 반영
  - TextLi에 클릭 이벤트 추가
  - MountainCardSection 추가 및 데이터 삽입/가공
  - MountainCard 클릭 이벤트 추가
  - Loading 추가
  - SearchBar 수정: 선택된 산/코스/요일 상태 지정 및 form 태그 적용
  - MainSearchSection 추가 (코스 데이터 API 요청 예정)

### 상태관리
 - MainPage
    - 서치바 뒤에 배경 (isOpen)
    - 전체 산 데이터
    - 선택한 산
    - 로딩 중 상태
    
- MainSearchSection
    - 산에 해당하는 전체 코스 데이터 (API 요청 예정)
    
- SearchBar
    - 어떤 드롭다운이 열렸는지
    - 선택된 산, 코스, 요일 ⇒ props로 전달받은 핸들러로 상위에 보냄

- MountainCardSection
    - 상태없음 (전체 산 리스트 API 요청 예정)
    