### PR TITLE
[BE] - 🐞 BugFix: 산악 단기 배치 서버 오류 수정

### DIFF
--- a/backend/application-modules/batch-server/src/main/java/com/softeer/batch/common/writersupporter/SunTimeJdbcWriter.java
+++ b/backend/application-modules/batch-server/src/main/java/com/softeer/batch/common/writersupporter/SunTimeJdbcWriter.java
@@ -1,5 +1,6 @@
 package com.softeer.batch.common.writersupporter;
 
+import com.softeer.batch.forecast.mountain.dto.DailySunTime;
 import com.softeer.batch.forecast.mountain.dto.MountainDailyForecast;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -9,6 +10,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Component
 @StepScope
@@ -28,11 +30,14 @@ public class SunTimeJdbcWriter {
         }
     }
 
-    public MapSqlParameterSource createSunTimeParams(MountainDailyForecast item) {
-        return new MapSqlParameterSource()
-                .addValue("sunrise", item.sunTime().sunrise())
-                .addValue("sunset", item.sunTime().sunset())
-                .addValue("date", LocalDate.now())
-                .addValue("mountainId", item.mountainId());
+    public List<MapSqlParameterSource> createSunTimeParams(MountainDailyForecast item) {
+        return item.dailySunTimes().stream()
+                .map(dailySunTime -> new MapSqlParameterSource()
+                        .addValue("sunrise", dailySunTime.sunTime().sunrise())
+                        .addValue("sunset", dailySunTime.sunTime().sunset())
+                        .addValue("date", dailySunTime.date())
+                        .addValue("mountainId", item.mountainId())
+                )
+                .toList();
     }
 }

--- a/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/dto/DailySunTime.java
+++ b/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/dto/DailySunTime.java
@@ -1,0 +1,19 @@
+package com.softeer.batch.forecast.mountain.dto;
+
+import com.softeer.domain.SunTime;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record DailySunTime(
+        LocalDate date,
+        SunTime sunTime
+) {
+    public DailySunTime(
+            LocalDate date,
+            LocalTime sunrise,
+            LocalTime sunset
+    ) {
+        this(date, new SunTime(sunrise, sunset));
+    }
+}

--- a/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/dto/MountainDailyForecast.java
+++ b/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/dto/MountainDailyForecast.java
@@ -9,22 +9,7 @@ import java.util.List;
 public record MountainDailyForecast(
         long mountainId,
         int gridId,
-        SunTime sunTime,
+        List<DailySunTime> dailySunTimes,
         List<Forecast> hourlyForecasts
 ) {
-
-    public MountainDailyForecast(
-            long mountainId,
-            int gridId,
-            LocalTime sunrise,
-            LocalTime sunset,
-            List<Forecast> hourlyForecasts
-    ) {
-        this(
-                mountainId,
-                gridId,
-                new SunTime(sunrise, sunset),
-                hourlyForecasts
-        );
-    }
 }

--- a/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/writer/AbstractMountainForecastWriter.java
+++ b/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/mountain/writer/AbstractMountainForecastWriter.java
@@ -28,8 +28,8 @@ public abstract class AbstractMountainForecastWriter implements ItemWriter<Mount
 
     private void writeSunTime(Chunk<? extends MountainDailyForecast> chunk) {
         SqlParameterSource[] sunTimeParams = chunk.getItems().stream()
-                .filter(item -> item.sunTime() != null && item.sunTime().sunrise() != null)
                 .map(sunTimeJdbcWriter::createSunTimeParams)
+                .flatMap(List::stream)
                 .toArray(SqlParameterSource[]::new);
 
         sunTimeJdbcWriter.batchUpdateSunTime(sunTimeParams);

--- a/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/shortterm/config/ShortForecastJobConfig.java
+++ b/backend/application-modules/batch-server/src/main/java/com/softeer/batch/forecast/shortterm/config/ShortForecastJobConfig.java
@@ -44,7 +44,7 @@ public class ShortForecastJobConfig {
 
     @Bean(name = START_UP_SHORT_FORECAST_JOB)
     public Job startupForecastJob() {
-        return new JobBuilder(START_UP_SHORT_FORECAST_STEP, jobRepository)
+        return new JobBuilder(START_UP_SHORT_FORECAST_JOB, jobRepository)
                 .start(startupShortForecastStep())
                 .build();
     }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
산악 단기 API 데이터 배치 처리 오류를 수정함.


## 작업사항
- 일출, 일몰 시간 저장 로직을 수정함.
  - 기존: api 호출 당일의 일출, 일몰 시간만 저장됨.
  - 변경: api 호출 후 응답 데이터의 모든 일출, 일몰 시간을 저장함.
- api에서 일출, 일몰 시간을 제공하지 않는 산의 경우 기본값을 일출, 일몰 시간으로 저장함.


## 변경로직
- 기존 일출, 일몰 시간 저장 로직을 개선함.
- 날짜, 일출, 일몰 시간을 담는 레코드를 생성하여 당일 뿐만 아니라 여러 날짜의 일출, 일몰 시간을 처리할 수 있도록 함.

close #207 
