### PR TITLE
[FE] - ✨ Feature: 예보페이지 로딩창 구현

### DIFF
--- a/frontend/src/components/organisms/Loading/Loading.tsx
+++ b/frontend/src/components/organisms/Loading/Loading.tsx
@@ -28,12 +28,13 @@ export default function Loading(props: PropsState) {
 const { colors } = theme;
 
 const fullScreenContainerStyle = css`
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    right: 0;
+    bottom: 0;
     background-color: ${colors.grey[0]};
+    z-index: 10010;
 `;
 
 const fillProgress = keyframes`

--- a/frontend/src/components/templates/Forecast/ForecastSearchSection.tsx
+++ b/frontend/src/components/templates/Forecast/ForecastSearchSection.tsx
@@ -10,6 +10,7 @@ import {
     refactorCoursesDataToOptions,
     refactorMountainDataToOptions,
 } from '../Main/utils.ts';
+import Loading from '../../organisms/Loading/Loading.tsx';
 
 interface Option {
     id: number;
@@ -18,6 +19,7 @@ interface Option {
 
 export default function ForecastSearchSection() {
     const [searchParams, setSearchParams] = useSearchParams();
+    const [isLoading, setIsLoading] = useState(false);
     const mountainId = Number(searchParams.get('mountainid'));
     const courseId = Number(searchParams.get('courseid'));
     const weekdayId = Number(searchParams.get('weekdayid'));
@@ -44,6 +46,14 @@ export default function ForecastSearchSection() {
         },
     );
 
+    const selectedMountain = useMemo(() => {
+        return mountainsData?.find(
+            (mountain) => mountain.mountainId === selectedMountainId,
+        );
+    }, [mountainsData, selectedMountainId]);
+    const mountainTitle = selectedMountain?.mountainName ?? '';
+    const mountainDescription = selectedMountain?.mountainDescription ?? '';
+
     const mouuntainChangeHandler = (id: number) => {
         setSelectedMountainId(id);
         setSelectedCourseId(0);
@@ -56,6 +66,12 @@ export default function ForecastSearchSection() {
     };
     const submitHandler = (e: React.FormEvent) => {
         e.preventDefault();
+        if (
+            selectedMountainId === 0 ||
+            selectedCourseId === 0 ||
+            selectedWeekdayId === 0
+        )
+            return;
 
         const next = new URLSearchParams(searchParams);
         next.set('mountainid', String(selectedMountainId));
@@ -91,22 +107,38 @@ export default function ForecastSearchSection() {
         next.set('weekdayid', String(weekdayData[0].id));
         setSearchParams(next);
     }, []);
+    useEffect(() => {
+        setIsLoading(true);
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 3000);
+
+        return () => clearTimeout(timer);
+    }, [mountainId]);
 
     return (
-        <SearchBar
-            searchBarMessage='를 오르는'
-            pageName='main'
-            mountainOptions={mountainOptions}
-            selectedMountainId={selectedMountainId ?? 0}
-            mountainChangeHandler={mouuntainChangeHandler}
-            courseOptions={courseOptions}
-            selectedCourseId={selectedCourseId ?? 0}
-            courseChangeHandler={courseChangeHandler}
-            weekdayOptions={weekdayData}
-            selectedWeekdayId={selectedWeekdayId ?? 0}
-            weekdayChangeHandler={weekdayChangeHandler}
-            onSubmit={submitHandler}
-        />
+        <>
+            <SearchBar
+                searchBarMessage='를 오르는'
+                pageName='main'
+                mountainOptions={mountainOptions}
+                selectedMountainId={selectedMountainId ?? 0}
+                mountainChangeHandler={mouuntainChangeHandler}
+                courseOptions={courseOptions}
+                selectedCourseId={selectedCourseId ?? 0}
+                courseChangeHandler={courseChangeHandler}
+                weekdayOptions={weekdayData}
+                selectedWeekdayId={selectedWeekdayId ?? 0}
+                weekdayChangeHandler={weekdayChangeHandler}
+                onSubmit={submitHandler}
+            />
+            {isLoading && (
+                <Loading
+                    mountainTitle={mountainTitle}
+                    mountainDescription={mountainDescription}
+                />
+            )}
+        </>
     );
 }
 


### PR DESCRIPTION

<img width="1840" height="1121" alt="스크린샷 2025-08-25 오후 4 46 38" src="https://github.com/user-attachments/assets/bfcedd9c-a3af-4d3c-b20d-094f24eceafa" />


## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
예보페이지에서 산 및 코스 설정 후 검색 버튼 누를 때 및 초기 접근 시 로딩창을 구현했습니다


## 작업사항
- 예보검색섹션에서 로딩창을 부르도록 구현
- 로딩창의 z-index를 header보다 위로 오도록 수정

close #264
