### PR TITLE
[FE] - ✨ Feature : 최근 본 등산 카드 및 CardModal 구현, PATCH 메서드 지원 추가

### DIFF
--- a/frontend/src/components/atoms/Text/WeatherIndex.tsx
+++ b/frontend/src/components/atoms/Text/WeatherIndex.tsx
@@ -14,7 +14,7 @@ interface WeatherIdx {
 interface PropsState {
     type: WeatherType;
 }
-type WeatherType = '매우좋음' | '좋음' | '보통' | '나쁨';
+type WeatherType = '매우 좋음' | '좋음' | '약간 나쁨' | '나쁨';
 const { colors, typography } = theme;
 
 function WeatherIndex(props: WeatherIdx) {
@@ -71,7 +71,7 @@ function WeatherIndexVivid(props: PropsState) {
     let color;
 
     switch (type) {
-        case '매우좋음':
+        case '매우 좋음':
             color = colors.status.light.excellent;
             backGroundColor = colors.status.normal.excellent;
             break;
@@ -79,7 +79,7 @@ function WeatherIndexVivid(props: PropsState) {
             color = colors.status.light.good;
             backGroundColor = colors.status.normal.good;
             break;
-        case '보통':
+        case '약간 나쁨':
             color = colors.status.light.average;
             backGroundColor = colors.status.normal.average;
             break;
@@ -107,7 +107,7 @@ function WeatherIndexLight(props: PropsState) {
     let backGroundColor;
 
     switch (type) {
-        case '매우좋음':
+        case '매우 좋음':
             color = colors.status.normal.excellent;
             backGroundColor = colors.status.regular.excellent;
             break;
@@ -115,7 +115,7 @@ function WeatherIndexLight(props: PropsState) {
             color = colors.status.normal.good;
             backGroundColor = colors.status.regular.good;
             break;
-        case '보통':
+        case '약간 나쁨':
             color = colors.status.normal.average;
             backGroundColor = colors.status.regular.average;
             break;

--- a/frontend/src/components/molecules/Forecast/BackWeatherCardHeader.tsx
+++ b/frontend/src/components/molecules/Forecast/BackWeatherCardHeader.tsx
@@ -15,7 +15,7 @@ interface PropsState {
     };
 }
 
-type WeatherType = '매우좋음' | '좋음' | '보통' | '나쁨';
+type WeatherType = '매우 좋음' | '좋음' | '약간 나쁨' | '나쁨';
 
 export default function BackWeatherCardHeader({ headerData }: PropsState) {
     const {

--- a/frontend/src/components/molecules/Forecast/DetailSideBarSummary.tsx
+++ b/frontend/src/components/molecules/Forecast/DetailSideBarSummary.tsx
@@ -7,7 +7,7 @@ interface PropsState {
     hikingActivity: HikingActivity;
 }
 
-type HikingActivity = '매우좋음' | '좋음' | '보통' | '나쁨';
+type HikingActivity = '매우 좋음' | '좋음' | '약간 나쁨' | '나쁨';
 
 export default function DetailSideBarSummary({
     temperature,

--- a/frontend/src/components/molecules/Forecast/WeatherCell.tsx
+++ b/frontend/src/components/molecules/Forecast/WeatherCell.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import Icon from '../../atoms/Icon/Icons.tsx';
 import SelectorText from '../../atoms/Text/SelectorText.tsx';
+import { theme } from '../../../theme/theme.ts';
 
 interface PropsState {
     time: string;
@@ -13,9 +14,11 @@ export default function WeatherCell({
     temperature,
     iconName,
 }: PropsState) {
+    const newFormatTime = formatTime(time);
+
     return (
-        <div css={wrapperStyles}>
-            <SelectorText>{formatTime(time)}</SelectorText>
+        <div css={wrapperStyles(newFormatTime)}>
+            <SelectorText>{newFormatTime}</SelectorText>
             <Icon
                 name={iconName}
                 width={1.5}
@@ -63,7 +66,9 @@ function formatTime(timeStr: string) {
     return `${hours} ${ampm}`;
 }
 
-const wrapperStyles = css`
+const { colors } = theme;
+
+const wrapperStyles = (timeLabel: string) => css`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -72,4 +77,14 @@ const wrapperStyles = css`
     scroll-snap-align: start;
     width: 5rem;
     height: 7.875rem;
+
+    span:first-of-type {
+        background-color: ${timeLabel === '오늘' ||
+        timeLabel === '내일' ||
+        timeLabel === '모레'
+            ? colors.greyOpacityWhite[80]
+            : 'transparent'};
+        border-radius: 1.5rem;
+        width: 4rem;
+    }
 `;

--- a/frontend/src/components/organisms/Common/Header.tsx
+++ b/frontend/src/components/organisms/Common/Header.tsx
@@ -4,22 +4,22 @@ import LogoWithNav from '../../molecules/Header/LogoWithNav';
 import IconNavList from '../../molecules/Header/IconNavList';
 import { LabelHeading } from '../../atoms/Heading/Heading';
 import Icon from '../../atoms/Icon/Icons';
+import { theme } from '../../../theme/theme';
 
 export default function Header() {
     const location = useLocation();
     const isForecastPage = location.pathname.includes('/forecast');
-
     const navigate = useNavigate();
 
     return (
-        <header css={headerStyles}>
+        <header css={headerStyles(isForecastPage)}>
             <nav css={navStyles}>
                 {isForecastPage ? (
                     <>
                         <button
                             css={css`
                                 all: unset;
-                                cursor: hover;
+                                cursor: pointer;
                             `}
                             onClick={() => navigate('/')}
                         >
@@ -45,7 +45,9 @@ export default function Header() {
     );
 }
 
-const headerStyles = css`
+const { colors } = theme;
+
+const headerStyles = (isForecastPage: boolean) => css`
     position: sticky;
     top: 0;
     z-index: 10000;
@@ -55,11 +57,13 @@ const headerStyles = css`
     height: 5rem;
     padding: 0 4rem;
     box-sizing: border-box;
-    background: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0.5) 0%,
-        rgba(0, 0, 0, 0) 100%
-    );
+    background: ${isForecastPage
+        ? `linear-gradient(
+            to bottom,
+            rgba(0, 0, 0, 0.5) 0%,
+            rgba(0, 0, 0, 0) 100%
+        )`
+        : colors.grey[0]};
 `;
 
 const navStyles = css`

--- a/frontend/src/components/organisms/Forecast/DetailSideBarContentColumn.tsx
+++ b/frontend/src/components/organisms/Forecast/DetailSideBarContentColumn.tsx
@@ -40,7 +40,7 @@ export default function DetailSideBarContentColumn({
         {
             iconName: 'rain',
             title: '강수 확률',
-            value: `${precipitation}%`,
+            value: precipitation,
             description: probabilityDescription,
         },
         {

--- a/frontend/src/components/organisms/Forecast/TimeSeletor.tsx
+++ b/frontend/src/components/organisms/Forecast/TimeSeletor.tsx
@@ -108,7 +108,6 @@ export default function TimeSeletor({
             ? scrollStartTimeStr
             : startTimeStr;
         const startDate = new Date(seletedTime);
-        console.log(scrollStartTimeStr);
 
         const formatTime = (date: Date) => {
             const hours = date.getHours();

--- a/frontend/src/components/organisms/Forecast/TimeSeletor.tsx
+++ b/frontend/src/components/organisms/Forecast/TimeSeletor.tsx
@@ -63,8 +63,8 @@ export default function TimeSeletor({
             behavior: 'smooth',
         });
 
-        const visibleIndex = Math.min(nearestIndex, data.length - 1);
-        const selectedTime = data[visibleIndex]?.dateTime;
+        const visibleIndex = Math.min(nearestIndex, (data?.length ?? 1) - 1);
+        const selectedTime = data?.[visibleIndex]?.dateTime;
 
         if (selectedTime && onTimeSelect) {
             onTimeSelect(selectedTime);

--- a/frontend/src/components/organisms/Forecast/WeatherSummaryCardModal.tsx
+++ b/frontend/src/components/organisms/Forecast/WeatherSummaryCardModal.tsx
@@ -4,14 +4,35 @@ import FrontWeatherSummaryCard from './FrontWeatherSummaryCard.tsx';
 import { useState } from 'react';
 import BackWeatherSummaryCard from './BackWeatherSummaryCard.tsx';
 import WeatherSummaryCardHeader from '../../molecules/Forecast/WeatherSummaryCardHeader.tsx';
+import Icon from '../../atoms/Icon/Icons.tsx';
+import useApiMutation from '../../../hooks/useApiMutation.ts';
 
 interface Props {
     cardData: any;
     onClose: () => void;
+    scrollSelectedDate: string;
+    selectedCourseId: number;
 }
 
-export default function WeatherSummaryCardModal({ onClose, cardData }: Props) {
+export default function WeatherSummaryCardModal({
+    onClose,
+    cardData,
+    scrollSelectedDate,
+    selectedCourseId,
+}: Props) {
     const [isFront, setIsFront] = useState<boolean>(true);
+    const storeMountainCardMutation = useApiMutation<any>(
+        `/card/interaction/history/${selectedCourseId}`,
+        'PUT',
+        {
+            onSuccess: () => {
+                alert('최근 본 등산목록에 추가되었습니다.');
+            },
+            onError: (err) => alert(`${err.message}`),
+        },
+        { startDateTime: scrollSelectedDate },
+    );
+
     return (
         <div css={overlayStyles} onClick={onClose}>
             <WeatherSummaryCardHeader />
@@ -33,6 +54,17 @@ export default function WeatherSummaryCardModal({ onClose, cardData }: Props) {
                     <BackWeatherSummaryCard cardData={cardData.backCard} />
                 </div>
             </div>
+            <button
+                onClick={() => storeMountainCardMutation.mutate({})}
+                css={storeBtnStyles}
+            >
+                <Icon
+                    name='download-02'
+                    width={1.4}
+                    height={1.4}
+                    color='grey-100'
+                />
+            </button>
         </div>
     );
 }
@@ -93,4 +125,21 @@ const modalStyles = (isFront: boolean, mountainImageUrl?: string) => css`
         justify-content: space-between;
         padding: 1.5rem;
     }
+`;
+
+const storeBtnStyles = css`
+    all: unset;
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    top: 28%;
+    left: calc(50% + 14rem);
+    width: 3rem;
+    height: 3rem;
+    border-radius: 100%;
+    background-color: ${colors.grey[40]};
+    padding: 0 3px 5px 0;
+    box-sizing: border-box;
+    cursor: pointer;
 `;

--- a/frontend/src/components/templates/Forecast/DetailInfoSection.tsx
+++ b/frontend/src/components/templates/Forecast/DetailInfoSection.tsx
@@ -11,13 +11,14 @@ import WeatherDetailSideBar from '../../organisms/Forecast/WeatherDetailSideBar.
 import Icon from '../../atoms/Icon/Icons.tsx';
 import { theme } from '../../../theme/theme.ts';
 import WeatherCardModal from '../../organisms/Forecast/WeatherSummaryCardModal.tsx';
+import { useSearchParams } from 'react-router-dom';
+import { useForecastCardData } from '../../../hooks/useForecastCardData.ts';
+import useApiQuery from '../../../hooks/useApiQuery.ts';
+import { keepPreviousData } from '@tanstack/react-query';
 import {
     detailInfoSectionData,
     summaryInfoSectionData,
 } from '../../../constants/placeholderData.ts';
-import { useSearchParams } from 'react-router-dom';
-import { useForecastCardData } from '../../../hooks/useForecastCardData.ts';
-import useApiQuery from '../../../hooks/useApiQuery.ts';
 
 interface CourseForcast {
     startCard: CardData;
@@ -52,8 +53,6 @@ interface CardData {
 type HikingActivityStatus = '좋음' | '매우좋음' | '나쁨' | '보통';
 type Background = 'sunny' | 'cloudy' | 'snow' | 'rain';
 
-const placeholderData = detailInfoSectionData;
-
 export default function DetailInfoSection() {
     const [searchParams] = useSearchParams();
     const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -77,19 +76,22 @@ export default function DetailInfoSection() {
     );
 
     const cardData = { frontCard, backCard };
-    const { data: courseForecastData = placeholderData } =
+    const { data: courseForecastData = detailInfoSectionData } =
         useApiQuery<CourseForcast>(
             `/card/course/${selectedCourseId}/forecast`,
             { startDateTime: scrollSeletedTime },
-            { placeholderData: placeholderData, enabled: true },
+            {
+                placeholderData: keepPreviousData,
+                enabled: true,
+            },
         );
 
-    const { data: summaryInfoData } = useApiQuery<any>(
+    const { data: summaryInfoData = summaryInfoSectionData } = useApiQuery<any>(
         `/card/mountain/course/${selectedCourseId}`,
         { dateTime: scrollSeletedTime },
         {
-            placeholderData: summaryInfoSectionData,
             retry: false,
+            placeholderData: keepPreviousData,
         },
     );
 

--- a/frontend/src/components/templates/Forecast/DetailInfoSection.tsx
+++ b/frontend/src/components/templates/Forecast/DetailInfoSection.tsx
@@ -50,7 +50,7 @@ interface CardData {
     title?: string;
 }
 
-type HikingActivityStatus = '좋음' | '매우좋음' | '나쁨' | '보통';
+type HikingActivityStatus = '좋음' | '매우 좋음' | '나쁨' | '약간 나쁨';
 type Background = 'sunny' | 'cloudy' | 'snow' | 'rain';
 
 export default function DetailInfoSection() {
@@ -212,7 +212,7 @@ export default function DetailInfoSection() {
                             })}
                         </div>
                         <img css={lineImageStyles} src={svg}></img>
-                        <WeatherIndexLight type='좋음' />
+                        <WeatherIndexLight type={startCard.hikingActivity} />
                     </div>
 
                     <TimeSeletor
@@ -240,6 +240,8 @@ export default function DetailInfoSection() {
                     <WeatherCardModal
                         cardData={cardData}
                         onClose={() => setIsCard(false)}
+                        scrollSelectedDate={scrollSeletedTime}
+                        selectedCourseId={selectedCourseId}
                     />
                 )}
             </div>

--- a/frontend/src/components/templates/MyPage/MyInfoSection.tsx
+++ b/frontend/src/components/templates/MyPage/MyInfoSection.tsx
@@ -16,6 +16,7 @@ interface UserData {
 export default function MyInfoSection() {
     const [isEditingNickName, setIsEditingNickName] = useState<boolean>(false);
     const inputNickNameRef = useRef<HTMLInputElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     const { data: myInfoData } = useApiQuery<UserData>(
         `/user`,
@@ -32,6 +33,15 @@ export default function MyInfoSection() {
         onSuccess: () => setIsEditingNickName(false),
         onError: () => alert('잠시 후 다시 시도해주세요'),
     });
+
+    const updateProfileImageMutation = useApiMutation<FormData, any>(
+        '/user/image', // 실제 API 엔드포인트 /user/nickname → /user/image 같은 실제 엔드포인트로 바꿔야 함
+        'PATCH',
+        {
+            onSuccess: () => alert('프로필 이미지가 변경되었습니다!'),
+            onError: (err: any) => alert(err.message || '업로드 실패'),
+        },
+    );
 
     const handleSave = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -59,6 +69,19 @@ export default function MyInfoSection() {
         } catch (err: any) {
             alert(err.message);
         }
+    };
+
+    const handleFileClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('imageFile', file);
+
+        updateProfileImageMutation.mutate(formData);
     };
 
     if (!myInfoData) return <div>loading!!</div>;
@@ -121,7 +144,16 @@ export default function MyInfoSection() {
                     </CommonText>
                 </div>
             </div>
-            <button css={buttonStyles}>개인 정보 변경</button>
+            <button css={buttonStyles} onClick={handleFileClick}>
+                사진 변경
+            </button>
+            <input
+                type='file'
+                accept='image/*'
+                ref={fileInputRef}
+                style={{ display: 'none' }}
+                onChange={handleFileChange}
+            />
         </div>
     );
 }

--- a/frontend/src/components/templates/MyPage/MyInfoSection.tsx
+++ b/frontend/src/components/templates/MyPage/MyInfoSection.tsx
@@ -50,7 +50,16 @@ export default function MyInfoSection() {
         '/user/image',
         'PATCH',
         {
-            onSuccess: () => alert('프로필 이미지가 변경되었습니다!'),
+            onSuccess: (_data, variables) => {
+                const file = variables.get('imageFile') as File;
+                if (!file) return;
+
+                const imageUrl = URL.createObjectURL(file);
+
+                queryClient.setQueryData<UserData>(['/user', {}], (old) =>
+                    old ? { ...old, imageUrl } : old,
+                );
+            },
             onError: (err: any) => alert(err.message || '업로드 실패'),
         },
     );

--- a/frontend/src/components/templates/MyPage/RecentClimbSection.tsx
+++ b/frontend/src/components/templates/MyPage/RecentClimbSection.tsx
@@ -14,7 +14,11 @@ interface RecentClimbData {
     courseName: string;
 }
 
-export default function RecentClimbSection() {
+interface PropsState {
+    onClick: (courseId: number, forecastDate: string) => void;
+}
+
+export default function RecentClimbSection({ onClick }: PropsState) {
     const { data: recentClimbData } = useApiQuery<RecentClimbData[]>(
         `/card/interaction/history`,
         { pageSize: 5 },
@@ -28,59 +32,62 @@ export default function RecentClimbSection() {
         return dateStr.split('T')[0].replace(/-/g, '.');
     };
 
+    if (!recentClimbData) return <div>loading....</div>;
+
     return (
         <div>
             <LabelHeading HeadingTag='h2'>최근 본 등산일정</LabelHeading>
             <div css={listStyles}>
                 {recentClimbData?.map((item, index) => {
-                    const {
-                        id,
-                        courseId,
-                        forecastDate,
-                        updatedAt,
-                        mountainName,
-                        courseName,
-                    } = item;
+                    const { forecastDate, mountainName, courseName, courseId } =
+                        item;
 
                     return (
-                        <div css={wrapperStyles} key={index}>
-                            <div css={headerStyles}>
-                                <CommonText
-                                    TextTag='span'
-                                    fontSize='caption'
-                                    fontWeight='medium'
-                                    color='grey-80'
-                                >
-                                    {formatDate(forecastDate)}
-                                </CommonText>
-                                <button css={buttonStyles}>
-                                    <Icon
-                                        name='narrow-right'
-                                        width={2}
-                                        height={2}
-                                        color='grey-0'
-                                    />
-                                </button>
+                        <>
+                            <div css={wrapperStyles} key={index}>
+                                <div css={headerStyles}>
+                                    <CommonText
+                                        TextTag='span'
+                                        fontSize='caption'
+                                        fontWeight='medium'
+                                        color='grey-80'
+                                    >
+                                        {formatDate(forecastDate)}
+                                    </CommonText>
+                                    <button
+                                        css={buttonStyles}
+                                        onClick={() =>
+                                            onClick(courseId, forecastDate)
+                                        }
+                                    >
+                                        <Icon
+                                            name='narrow-right'
+                                            width={2}
+                                            height={2}
+                                            color='grey-0'
+                                        />
+                                    </button>
+                                </div>
+                                <div css={contentWrapper}>
+                                    <CommonText
+                                        TextTag='span'
+                                        fontSize='body'
+                                        fontWeight='bold'
+                                        color='grey-100'
+                                    >
+                                        {mountainName}
+                                    </CommonText>
+                                    <CommonText
+                                        TextTag='span'
+                                        fontSize='body'
+                                        fontWeight='bold'
+                                        color='grey-100'
+                                    >
+                                        {courseName}
+                                    </CommonText>
+                                </div>
                             </div>
-                            <div css={contentWrapper}>
-                                <CommonText
-                                    TextTag='span'
-                                    fontSize='body'
-                                    fontWeight='bold'
-                                    color='grey-100'
-                                >
-                                    {mountainName}
-                                </CommonText>
-                                <CommonText
-                                    TextTag='span'
-                                    fontSize='body'
-                                    fontWeight='bold'
-                                    color='grey-100'
-                                >
-                                    {courseName}
-                                </CommonText>
-                            </div>
-                        </div>
+                        </>
                     );
                 })}
             </div>

--- a/frontend/src/components/templates/MyPage/WeatherSummaryCard.tsx
+++ b/frontend/src/components/templates/MyPage/WeatherSummaryCard.tsx
@@ -1,0 +1,104 @@
+import { css } from '@emotion/react';
+import { theme } from '../../../theme/theme.ts';
+import { useState } from 'react';
+import FrontWeatherSummaryCard from '../../organisms/Forecast/FrontWeatherSummaryCard';
+import BackWeatherSummaryCard from '../../organisms/Forecast/BackWeatherSummaryCard.tsx';
+import { useForecastCardData } from '../../../hooks/useForecastCardData.ts';
+
+interface Props {
+    courseId: number;
+    forecastDate: string;
+    onClose: () => void;
+}
+
+export default function WeatherSummaryCardModal({
+    onClose,
+    courseId,
+    forecastDate,
+}: Props) {
+    const [isFront, setIsFront] = useState<boolean>(true);
+    const { frontCard, backCard } = useForecastCardData(courseId, forecastDate);
+    const cardData = { frontCard, backCard };
+
+    if (!cardData) return <div>loading...</div>;
+
+    return (
+        <div css={overlayStyles} onClick={onClose}>
+            <div
+                css={modalStyles(isFront, cardData.frontCard.mountainImageUrl)}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setIsFront((prev) => !prev);
+                }}
+            >
+                <div className='front'>
+                    <FrontWeatherSummaryCard
+                        cardData={cardData.frontCard}
+                        onClose={onClose}
+                    />
+                </div>
+                <div className='back'>
+                    <BackWeatherSummaryCard cardData={cardData.backCard} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const { colors } = theme;
+
+const overlayStyles = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: ${colors.greyOpacity[10]};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    z-index: 2000;
+`;
+
+const modalStyles = (isFront: boolean, mountainImageUrl?: string) => css`
+    width: 22rem;
+    height: 35rem;
+    cursor: pointer;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.8s cubic-bezier(0.77, 0, 0.175, 1);
+    transform: ${isFront ? 'rotateY(0deg)' : 'rotateY(180deg)'};
+
+    .front,
+    .back {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        border-radius: 2rem;
+        box-sizing: border-box;
+        backface-visibility: hidden;
+        top: 0;
+        left: 0;
+    }
+
+    .front {
+        background: ${mountainImageUrl
+            ? `linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(${mountainImageUrl}) no-repeat center center / cover`
+            : colors.grey[20]};
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        padding: 1.5rem;
+    }
+
+    .back {
+        background: ${colors.grey[100]};
+        transform: rotateY(180deg);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        padding: 1.5rem;
+    }
+`;

--- a/frontend/src/hooks/useApiMutation.ts
+++ b/frontend/src/hooks/useApiMutation.ts
@@ -16,10 +16,18 @@ export default function useApiMutation<TRequest = any, TResponse = any>(
     url: string,
     method: Method = 'POST',
     options?: UseMutationOptions<TResponse | string, Error, TRequest>,
+    prams?: Record<string, any>,
 ): UseMutationResult<TResponse | string, Error, TRequest> {
     const mutationFn = async (body: TRequest): Promise<TResponse | string> => {
         const token = getToken();
         const isFormData = body instanceof FormData;
+        const queryString =
+            prams && Object.keys(prams).length
+                ? '?' +
+                  new URLSearchParams(
+                      prams as Record<string, string>,
+                  ).toString()
+                : '';
 
         const headers: HeadersInit = isFormData
             ? token
@@ -30,7 +38,7 @@ export default function useApiMutation<TRequest = any, TResponse = any>(
                   ...(token ? { Authorization: `Bearer ${token}` } : {}),
               };
 
-        const res = await fetch(`${API_BASE_URL}${url}`, {
+        const res = await fetch(`${API_BASE_URL}${url}${queryString}`, {
             method,
             headers,
             body: isFormData ? body : JSON.stringify(body),

--- a/frontend/src/hooks/useApiMutation.ts
+++ b/frontend/src/hooks/useApiMutation.ts
@@ -6,7 +6,7 @@ import {
     type UseMutationResult,
 } from '@tanstack/react-query';
 
-type Method = 'POST' | 'PUT' | 'DELETE';
+type Method = 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 const getToken = () =>
     localStorage.getItem('accessToken') ??

--- a/frontend/src/hooks/useForecastCardData.ts
+++ b/frontend/src/hooks/useForecastCardData.ts
@@ -1,4 +1,3 @@
-import { backCard, frontCard } from '../constants/placeholderData';
 import useApiQuery from './useApiQuery';
 
 export const useForecastCardData = (
@@ -8,15 +7,14 @@ export const useForecastCardData = (
     const { data: frontData, refetch: refetchFront } = useApiQuery<any>(
         `/card/mountain/course/${selectedCourseId}`,
         { dateTime: seletedTime },
-        { retry: false, enabled: true, placeholderData: frontCard },
+        { retry: false, enabled: true },
     );
 
     const { data: backData, refetch: refetchBack } = useApiQuery<any>(
         `/card/mountain/course/${selectedCourseId}/schedule`,
         { startDateTime: seletedTime },
-        { retry: false, enabled: true, placeholderData: backCard },
+        { retry: false, enabled: true },
     );
-    console.log('do');
     return {
         frontCard: frontData,
         backCard: backData,

--- a/frontend/src/hooks/useForecastCardData.ts
+++ b/frontend/src/hooks/useForecastCardData.ts
@@ -8,15 +8,15 @@ export const useForecastCardData = (
     const { data: frontData, refetch: refetchFront } = useApiQuery<any>(
         `/card/mountain/course/${selectedCourseId}`,
         { dateTime: seletedTime },
-        { retry: false, enabled: false, placeholderData: frontCard },
+        { retry: false, enabled: true, placeholderData: frontCard },
     );
 
     const { data: backData, refetch: refetchBack } = useApiQuery<any>(
         `/card/mountain/course/${selectedCourseId}/schedule`,
         { startDateTime: seletedTime },
-        { retry: false, enabled: false, placeholderData: backCard },
+        { retry: false, enabled: true, placeholderData: backCard },
     );
-
+    console.log('do');
     return {
         frontCard: frontData,
         backCard: backData,

--- a/frontend/src/pages/MyPage/MyPage.tsx
+++ b/frontend/src/pages/MyPage/MyPage.tsx
@@ -1,19 +1,44 @@
 import { css } from '@emotion/react';
 import MyInfoSection from '../../components/templates/MyPage/MyInfoSection';
-import { userInfoData } from '../../constants/placeholderData.ts';
 import RecentClimbSection from '../../components/templates/MyPage/RecentClimbSection.tsx';
 import MyReportSection from '../../components/templates/MyPage/MyReportSection.tsx';
 import MyLikeSection from '../../components/templates/MyPage/MyLikeSection.tsx';
-
-const placeholderUserData = userInfoData;
+import { useState } from 'react';
+import WeatherSummaryCardModal from '../../components/templates/MyPage/WeatherSummaryCard.tsx';
 
 export default function MyPage() {
+    const [isCard, setIsCard] = useState<boolean>(false);
+    const [selectedCourseId, setSelectedCourseId] = useState<number | null>(
+        null,
+    );
+    const [selectedForecastDate, setSelectedForecastDate] = useState<
+        string | null
+    >(null);
+
+    const handleBtnClick = (courseId: number, forecastDate: string) => {
+        setSelectedCourseId(courseId);
+        setSelectedForecastDate(forecastDate);
+        setIsCard(true);
+    };
+
     return (
         <div css={wrapperStyles}>
-            <MyInfoSection userData={placeholderUserData} />
-            <RecentClimbSection />
+            <MyInfoSection />
+            <RecentClimbSection
+                onClick={(courseId, forecastDate) =>
+                    handleBtnClick(courseId, forecastDate)
+                }
+            />
+
             <MyReportSection />
             <MyLikeSection />
+            {isCard && (
+                <WeatherSummaryCardModal
+                    onClose={() => setIsCard(false)}
+                    courseId={selectedCourseId!}
+                    forecastDate={selectedForecastDate!}
+                />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feature
📝 Documents
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

https://github.com/user-attachments/assets/638e2fe4-33cb-4536-aaff-302807a5e614
Uploading 화면 기록 2025-08-25 오후 4.46.16.mov…



## PR 설명
최근 본 등산 카드 및 CardModal 컴포넌트 관련 기능을 추가하고, 닉네임/이미지 변경 로직을 포함한 PATCH 메서드 지원을 구현했습니다.
또한 placeholderData를 제거하고, keepPreviousData 옵션을 적용하여 UI 덜컹거림을 방지했습니다.


## 작업사항
- PATCH Method 지원 추가
- 최근 본 등산 목록 Card 생성 및 CardModal 컴포넌트 구현
- 닉네임 중복 검사 및 중복 검사 통과 시 PATCH 로 변경 기능 구현
- 이미지 변경 로직 추가 및 변경된 데이터가 자연스럽게 렌더링되도록 처리
- forecastPage에서만 header 그라데이션 적용
- placeholderData 삭제 및 console.log 제거
- keepPreviousData 적용으로 데이터 갱신 시 UI 덜컹거림 방지
- weatherType 변경에 따른 타입 수정
- useMutation에서 params를 받을 수 있도록 변
- 카드 생성 시 로그인 상태일 경우 최근 본 등산목록에 저장 버튼 추가


## 변경로직
- API 호출 시 PATCH Method를 사용할 수 있도록 useApiMutation 수정
- CardModal 내부에서 카드 flip, 닫기, 저장 로직 추가
- 닉네임 및 이미지 변경 시, PATCH 요청 후 상태를 갱신하여 자연스럽게 UI 반영
- keepPreviousData 활용으로 데이터 갱신 중에도 이전 데이터 유지 → UX 개선

close #91 